### PR TITLE
Send SAP packet

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"flag"
+	"github.com/itochan/aes67-transmitter/sap"
+)
+
+var (
+	interfaceName = flag.String("i", "", "Network interface")
+)
+
+func main() {
+	flag.Parse()
+
+	sap := sap.NewSAP(*interfaceName)
+	sap.AnnounceSAP()
+}

--- a/sap/sap.go
+++ b/sap/sap.go
@@ -106,7 +106,7 @@ func getLocalIPv4Address(interfaceName string) *net.IPNet {
 }
 
 func (sap *SAP) getUDPMulticastIP() net.IPNet {
-	ipAddr := getLocalIPv4Address(sap.interfaceName).IP
+	ipAddr := getLocalIPv4Address(sap.interfaceName).IP.To4()
 	return net.IPNet{
 		IP:   net.IPv4(239, 69, ipAddr[2], ipAddr[3]),
 		Mask: net.IPv4Mask(255, 254, 0, 0),

--- a/sap/sap.go
+++ b/sap/sap.go
@@ -108,7 +108,7 @@ func getLocalIPv4Address(interfaceName string) *net.IPNet {
 func (sap *SAP) getUDPMulticastIP() net.IPNet {
 	ipAddr := getLocalIPv4Address(sap.interfaceName).IP
 	return net.IPNet{
-		net.IPv4(239, 69, ipAddr[2], ipAddr[3]),
-		net.IPv4Mask(255, 254, 0, 0),
+		IP:   net.IPv4(239, 69, ipAddr[2], ipAddr[3]),
+		Mask: net.IPv4Mask(255, 254, 0, 0),
 	}
 }

--- a/sap/sap.go
+++ b/sap/sap.go
@@ -1,0 +1,114 @@
+package sap
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"os"
+)
+
+const (
+	sapAnnounceIP   = "239.255.255.255"
+	sapAnnouncePort = 9875
+)
+
+type SAP struct {
+	interfaceName string
+}
+
+func NewSAP(interfaceName string) *SAP {
+	return &SAP{interfaceName: interfaceName}
+}
+
+func (sap *SAP) AnnounceSAP() {
+	fmt.Println("Announce SAP...")
+	multicastAddress := sap.getUDPMulticastIP()
+	fmt.Printf("Multicast Address: %s:%d\n", multicastAddress.IP.String(), sapAnnouncePort)
+
+	hostAddress := getLocalIPv4Address(sap.interfaceName).IP
+	hostname, err := os.Hostname()
+	if err != nil {
+		hostname = "AES67 Device"
+	}
+	destinationAddr := net.UDPAddr{IP: net.ParseIP(sapAnnounceIP), Port: sapAnnouncePort}
+
+	headers := [][]byte{
+		{
+			0x20,       // Flags
+			0x00,       // Authentication Length
+			0xff, 0xff, //Message Identifier Hash
+		},
+		hostAddress.To4(),         // Originating Source
+		[]byte("application/sdp"), // Payload Type
+		{0x00},                    // Blank
+	}
+	var header = []byte{}
+	for _, h := range headers {
+		header = append(header, h...)
+	}
+
+	manifest := "v=0\r\n" +
+		fmt.Sprintf("o=- 4 0 IN IP4 %s\r\n", hostAddress) +
+		fmt.Sprintf("s=%s\r\n", hostname) +
+		fmt.Sprintf("c=IN IP4 %s\r\n", multicastAddress.String()) +
+		"t=0 0\r\n" +
+		"a=clock-domain:PTPv2 0\r\n" +
+		"m=audio 5004 RTP/AVP 98\r\n" +
+		fmt.Sprintf("c=IN IP4 %s\r\n", multicastAddress.String()) +
+		"a=rtpmap:98 L24/48000/2\r\n" +
+		"a=sync-time:0\r\n" +
+		"a=framecount:48\r\n" +
+		"a=ptime:1\r\n" +
+		"a=mediaclk:direct=0\r\n" +
+		"a=ts-refclk:ptp=IEEE1588-2008:FF-FF-FF-FF-FF-FF-FF-FF:0\r\n" +
+		"a=recvonly\r\n"
+
+	fmt.Println()
+	fmt.Print(manifest)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+	dialer := net.Dialer{
+		LocalAddr: &net.UDPAddr{IP: getLocalIPv4Address(sap.interfaceName).IP, Port: sapAnnouncePort},
+	}
+	connect, err := dialer.Dial("udp", destinationAddr.String())
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer connect.Close()
+	_, err = connect.Write(append(header, []byte(manifest)...))
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func getLocalIPv4Address(interfaceName string) *net.IPNet {
+	iface, err := net.InterfaceByName(interfaceName)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	addrs, err := iface.Addrs()
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, address := range addrs {
+		if ipnet, ok := address.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
+			if ipnet.IP.To4() != nil {
+				return ipnet
+			}
+		}
+	}
+
+	log.Fatalf("Can not get IPv4 address!!")
+	return nil
+}
+
+func (sap *SAP) getUDPMulticastIP() net.IPNet {
+	ipAddr := getLocalIPv4Address(sap.interfaceName).IP
+	return net.IPNet{
+		net.IPv4(239, 69, ipAddr[2], ipAddr[3]),
+		net.IPv4Mask(255, 254, 0, 0),
+	}
+}

--- a/sap/sap.go
+++ b/sap/sap.go
@@ -42,7 +42,7 @@ func (sap *SAP) AnnounceSAP() {
 		[]byte("application/sdp"), // Payload Type
 		{0x00},                    // Blank
 	}
-	var header = []byte{}
+	var header []byte
 	for _, h := range headers {
 		header = append(header, h...)
 	}

--- a/sap/sap.go
+++ b/sap/sap.go
@@ -36,7 +36,7 @@ func (sap *SAP) AnnounceSAP() {
 		{
 			0x20,       // Flags
 			0x00,       // Authentication Length
-			0xff, 0xff, //Message Identifier Hash
+			0xff, 0xff, // Message Identifier Hash
 		},
 		hostAddress.To4(),         // Originating Source
 		[]byte("application/sdp"), // Payload Type


### PR DESCRIPTION
SAP: Session Announcement Protocol
Necessary for receiving with a Dante device in AES67 mode.

Try `go run main.go -i [interface name]`

😎 

![image](https://user-images.githubusercontent.com/519604/69000262-2732f880-0910-11ea-8c51-61f605ebc018.png)